### PR TITLE
Handle Chrome session creation failures

### DIFF
--- a/Python Project Folder/Pinnacle_Scraper.py
+++ b/Python Project Folder/Pinnacle_Scraper.py
@@ -3,6 +3,7 @@ import time
 import csv
 import random
 import re
+import tempfile
 import undetected_chromedriver as uc
 import config
 from datetime import datetime, timedelta
@@ -10,6 +11,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import SessionNotCreatedException
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 
@@ -50,7 +52,13 @@ def init_driver():
     if user_data_dir:
         options.add_argument(f"--user-data-dir={user_data_dir}")
     options.add_argument("--profile-directory=Default")
-    driver = uc.Chrome(options=options)
+    try:
+        driver = uc.Chrome(options=options)
+    except SessionNotCreatedException:
+        temp_dir = tempfile.mkdtemp()
+        options = uc.ChromeOptions()
+        options.add_argument(f"--user-data-dir={temp_dir}")
+        driver = uc.Chrome(options=options)
     print("Chrome opened successfully!")
     return driver
 


### PR DESCRIPTION
## Summary
- Handle SessionNotCreated errors when launching undetected_chromedriver
- Retry Chrome startup with a temporary user-data-dir profile

## Testing
- `python -m py_compile 'Python Project Folder/Pinnacle_Scraper.py'`


------
https://chatgpt.com/codex/tasks/task_e_68abb3f7bc6c832cb2d88dd0f39020ee