### PR TITLE
Add optional BetOnline scraper toggle

### DIFF
--- a/Python Project Folder/config.py
+++ b/Python Project Folder/config.py
@@ -25,3 +25,6 @@ LEAGUES             = ["basketball_nba", "basketball_ncaab", "baseball_mlb"]
 ALLOWED_BOOKS       = ["pinnacle", "fanduel", "betonlineag", "draftkings"]   # adjust as needed
 ODDS_REGIONS        = "us,eu"
 ODDS_FORMAT         = "american"
+
+# Feature toggles
+ENABLE_BETONLINE    = False

--- a/Python Project Folder/hybrid_script.py
+++ b/Python Project Folder/hybrid_script.py
@@ -8,6 +8,14 @@ def hybrid_main():
     print("Starting Pinnacle scraper...")
     Pinnacle_Scraper.main()
 
+    try:
+        if getattr(config, "ENABLE_BETONLINE", False):
+            import BetOnline_Scraper
+            print("Starting BetOnline scraper...")
+            BetOnline_Scraper.main()
+    except Exception as e:
+        print(f"[WARN] BetOnline step skipped: {e}")
+
     print("Syncing CSV data to Google Sheets...")
     google_sheets_sync.partial_update_google_sheets()
 


### PR DESCRIPTION
## Summary
- add `ENABLE_BETONLINE` flag in config
- conditionally run BetOnline scraper with error handling in `hybrid_script`

## Testing
- `python -m py_compile 'Python Project Folder/config.py' 'Python Project Folder/hybrid_script.py'`


------
https://chatgpt.com/codex/tasks/task_e_68bb2b3db0d0832c92150ccb9ffd8727