### PR TITLE
Add basic odds labeling tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_clv_math.py
+++ b/tests/test_clv_math.py
@@ -1,0 +1,10 @@
+from core.odds_labeling import build_label, base_market, clean_half
+
+def test_half_fix():
+    assert clean_half("9Â½") == "9½"
+
+def test_totals_label():
+    assert build_label("totals","over","9.5") == "Over 9.5"
+
+def test_spreads_label():
+    assert build_label("spreads","Yankees","1.5") == "Yankees +1.5"


### PR DESCRIPTION
## Summary
- add unit tests for label building and half-point cleaning
- ensure tests can import package by adjusting Python path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb2bace76c832c8ae5d366849eb8b9