### PR TITLE
Add docs and basic odds labeling tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,14 @@ python clv_sync.py
 or run the full pipeline via `python hybrid_script.py`.
 This writes **Live/Detailed Odds** tabs and fills **Closing Line** / **CLV%** in the Bet sheet.
 
+# Bet Tracking Automation (Pipeline)
+- Python-only pipeline; single Google Sheet for Bets + Live Odds + Detailed Odds
+- Configure IDs in config.py; set ODDS_API_KEY via environment
+- Run: python hybrid_script.py
+
+Quick check
+
+```powershell
+python -m pytest -q tests 2>$null
+```
+

--- a/docs/CLV_SYNC.md
+++ b/docs/CLV_SYNC.md
@@ -1,10 +1,7 @@
-# CLV Sync
-
-`clv_sync.py` reads bets and odds from the same Google Sheet (`config.GOOGLE_SHEET_ID`).
-
-- Uses the **Detailed Odds** tab to locate closing prices for each bet.
-- Updates the Bet sheet with **Closing Line** and **CLV%** columns.
-
-Inputs: Bet rows with Event ID, Market, Bet, Odds, and Bookmaker.
-Outputs: each matching bet is populated with its closing line and calculated CLV%.
-Run after `odds_sync.py` or as part of `hybrid_script.py`.
+# CLV SYNC
+- Link by Event ID
+- Label rules:
+  - totals: "Over/Under N"
+  - spreads: "Team ±N"
+  - h2h: "Team"
+- Closing Line from Detailed Odds; CLV% = (p_close/p_entry - 1)×100

--- a/docs/ODDS_API.md
+++ b/docs/ODDS_API.md
@@ -1,9 +1,6 @@
-# Odds API Sync
-
-`odds_sync.py` pulls markets from [The Odds API](https://the-odds-api.com/) and writes them to the Google Sheet defined by `config.GOOGLE_SHEET_ID`.
-
-- **Live Odds** tab: league, event id, matchup, start time, and bookmaker count (one row per event).
-- **Detailed Odds** tab: one row per bookmaker × market × outcome for bets listed in the Bet sheet.
-
-Inputs: `ODDS_API_KEY`, `LEAGUES`, `ALLOWED_BOOKS`, and bet rows with Event ID / Market / Bet.
-Outputs: refreshed odds data used later by `clv_sync.py` to compute Closing Line and CLV%.
+# ODDS API
+- API Key: config.ODDS_API_KEY (env)
+- Leagues: config.LEAGUES
+- Allowed books: config.ALLOWED_BOOKS
+- Tabs: Live Odds (events snapshot), Detailed Odds (per event×book×market×outcome)
+- Markets normalized: alternate_spreads→spreads, alternate_totals→totals

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,9 +1,11 @@
 # RUNBOOK
-- 1) Scrape Pinnacle → Bet_Tracking.csv
-- 2) python google_sheets_sync.py
-- 3) python odds_sync.py
-- 4) python clv_sync.py
+1) Scrape Pinnacle → Bet_Tracking.csv
+2) python google_sheets_sync.py
+3) python odds_sync.py
+4) python clv_sync.py
+(or: python hybrid_script.py to run all)
 
 Troubleshooting:
-- Auth: regenerate credentials.json, share sheet with service account.
-- Headers: ensure header row indices in config.py and column names match docs/DATA_SCHEMA.md.
+- Auth: regenerate credentials.json, share sheet with service account email.
+- Headers: Bets header row=7, data row=8 (configurable). Detailed/Live headers on row 1.
+- CLV: needs Event ID, Market, Bet, Odds, Bookmaker.

--- a/tests/test_odds_labeling.py
+++ b/tests/test_odds_labeling.py
@@ -1,0 +1,10 @@
+from core.odds_labeling import build_label, clean_half, base_market
+
+def test_half():
+    assert clean_half("9Â½")=="9½"
+
+def test_totals():
+    assert build_label("totals","over","9.5")=="Over 9.5"
+
+def test_spreads():
+    assert build_label("spreads","Blue Jays","1.5")=="Blue Jays +1.5"


### PR DESCRIPTION
## Summary
- Document runbook, Odds API integration, and CLV sync rules
- Add quick pipeline overview and test command to README
- Introduce unit tests for odds label helpers

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb333caa10832cb65af2d6b15630a9