### PR TITLE
core: sheets helpers and odds_labeling

### DIFF
--- a/core/sheets.py
+++ b/core/sheets.py
@@ -1,22 +1,38 @@
+from typing import List
 import gspread
 from google.oauth2.service_account import Credentials
 
-
-def client():
-    return gspread.authorize(Credentials.from_service_account_file(
-        "credentials.json", scopes=["https://www.googleapis.com/auth/spreadsheets"]
-    ))
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
 
-def open_ws(sheet_id: str, tab: str):
-    gc = client()
-    sh = gc.open_by_key(sheet_id)
+def _client():
+    creds = Credentials.from_service_account_file("credentials.json", scopes=SCOPES)
+    return gspread.authorize(creds)
+
+
+def open_spreadsheet(sheet_id: str) -> gspread.Spreadsheet:
+    return _client().open_by_key(sheet_id)
+
+
+def open_ws(sheet_id: str, title: str, rows: int = 1000, cols: int = 26) -> gspread.Worksheet:
+    ss = open_spreadsheet(sheet_id)
     try:
-        return sh.worksheet(tab)
+        ws = ss.worksheet(title)
     except gspread.WorksheetNotFound:
-        return sh.add_worksheet(title=tab, rows=1000, cols=30)
+        ws = ss.add_worksheet(title=title, rows=rows, cols=cols)
+    return ws
 
 
-def write_header(ws, headers):
+def write_header(ws: gspread.Worksheet, header: List[str], header_row: int = 1):
     ws.clear()
-    ws.update("A1", [headers], value_input_option="USER_ENTERED")
+    col_count = max(len(header), ws.col_count)
+    if ws.col_count < col_count:
+        ws.resize(rows=ws.row_count, cols=col_count)
+    ws.update(f"A{header_row}", [header])
+
+
+def clear_below(ws: gspread.Worksheet, start_row: int, last_col_letter: str = "Z"):
+    end_row = ws.row_count
+    rng = f"A{start_row}:{last_col_letter}{end_row}"
+    ws.spreadsheet.batch_clear([rng])
+

--- a/tests/test_clv_math.py
+++ b/tests/test_clv_math.py
@@ -1,10 +1,14 @@
-from core.odds_labeling import build_label, base_market, clean_half
+from core.odds_labeling import build_label, base_market
 
-def test_half_fix():
-    assert clean_half("9Â½") == "9½"
+
+def test_base_market_moneyline():
+    assert base_market("moneyline") == "h2h"
+
 
 def test_totals_label():
-    assert build_label("totals","over","9.5") == "Over 9.5"
+    assert build_label("totals", "under", "9Â½") == "Under 9½"
+
 
 def test_spreads_label():
-    assert build_label("spreads","Yankees","1.5") == "Yankees +1.5"
+    assert build_label("spreads", "Yankees", "1.5") == "Yankees +1.5"
+

--- a/tests/test_odds_labeling.py
+++ b/tests/test_odds_labeling.py
@@ -1,10 +1,14 @@
-from core.odds_labeling import build_label, clean_half, base_market
+from core.odds_labeling import build_label, base_market
 
-def test_half():
-    assert clean_half("9Â½")=="9½"
+
+def test_base_market_ml():
+    assert base_market("alternate_ml") == "h2h"
+
 
 def test_totals():
-    assert build_label("totals","over","9.5")=="Over 9.5"
+    assert build_label("totals", "over", "9.5") == "Over 9.5"
+
 
 def test_spreads():
-    assert build_label("spreads","Blue Jays","1.5")=="Blue Jays +1.5"
+    assert build_label("spreads", "Blue Jays", "1.5") == "Blue Jays +1.5"
+


### PR DESCRIPTION
## Summary
- Expand Google Sheets helpers with client factory, flexible worksheet creation, header management, and range clearing.
- Refine odds labeling utilities with normalized names, signed point formatting, and improved base market mapping.
- Update tests for new odds labeling behavior and market handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3a56a1a0832cb604c367d4c1370a