### PR TITLE
Add odds_sync script for Live and Detailed odds sync

### DIFF
--- a/odds_sync.py
+++ b/odds_sync.py
@@ -2,193 +2,127 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import List
-
+from typing import List, Tuple
 import requests
-
-ROOT = Path(__file__).resolve().parent
-sys.path.append(str(ROOT / "Python Project Folder"))
 from core import sheets
-
 import config
 
-"""Synchronize odds data from The Odds API to Google Sheets."""
+ROOT = Path(__file__).resolve().parent
+sys.path.append(str(ROOT))
 
-def _norm_team(s: str) -> str:
-    s = (s or "").strip()
-    # very light normalization; expand as needed
+def _norm_team(name: str) -> str:
+    s = (name or "").strip()
     s = re.sub(r"\s+", " ", s)
-    s = re.sub(r"\bSt(?!\.)\b", "State", s, flags=re.I)
-    s = s.replace("Â½","½")
+    s = s.replace("Â½", "½")
     return s
 
 def refresh_live_odds():
-    ws = sheets.open_ws(config.GOOGLE_SHEET_ID, config.LIVE_ODDS_TAB)
+    ws_live = sheets.open_ws(config.GOOGLE_SHEET_ID, config.LIVE_ODDS_TAB)
     header = ["League", "Event ID", "Event/Match", "Commence Time", "Bookmaker Count"]
-    sheets.write_header(ws, header)
-
-    rowbuf = []
+    sheets.write_header(ws_live, header, header_row=1)
+    rows: List[List[str]] = []
     for league in config.LEAGUES:
         url = f"https://api.the-odds-api.com/v4/sports/{league}/odds"
-        params = {
-            "apiKey": config.ODDS_API_KEY,
-            "regions": config.ODDS_REGIONS,
-            "oddsFormat": config.ODDS_FORMAT,
-            "markets": "h2h,spreads,totals"
-        }
-        r = requests.get(url, params=params, timeout=20)
+        params = {"apiKey": config.ODDS_API_KEY, "regions": config.ODDS_REGIONS, "oddsFormat": config.ODDS_FORMAT, "markets": "h2h,spreads,totals"}
+        try:
+            r = requests.get(url, params=params, timeout=20)
+        except Exception as e:
+            print(f"[ERROR] Live odds request failed for {league}: {e}")
+            continue
         if r.status_code != 200:
             print(f"[WARN] Live odds {league} HTTP {r.status_code}: {r.text[:200]}")
             continue
-        data = r.json()
-        for evt in data:
-            home = _norm_team(evt.get("home_team",""))
-            away = _norm_team(evt.get("away_team",""))
-            matchup = f"{home} vs {away}".strip()
-            event_id = evt.get("id","")
-            commence = evt.get("commence_time","")
-            bk_count = len(evt.get("bookmakers",[]))
-            rowbuf.append([league, event_id, matchup, commence, bk_count])
+        for ev in r.json():
+            home = _norm_team(ev.get("home_team", ""))
+            away = _norm_team(ev.get("away_team", ""))
+            matchup = f"{home} vs {away}" if (home and away) else (ev.get("sport_title") or "")
+            rows.append([league, ev.get("id",""), matchup, ev.get("commence_time",""), len(ev.get("bookmakers", []))])
+    if rows:
+        ws_live.update("A2", rows, value_input_option="USER_ENTERED")
+    print(f"[Live Odds] Wrote {len(rows)} events across {len(config.LEAGUES)} leagues.")
 
-    if rowbuf:
-        ws.update(f"A2", rowbuf, value_input_option="USER_ENTERED")
-    print(f"[Live Odds] Wrote {len(rowbuf)} rows.")
-
-def _build_user_market_and_label(mkt_key: str, outcome: dict, league: str, bet_select_hint: str = "") -> (str, str, str):
-    """
-    Returns (user_market, name_norm, point_str)
-    - user_market is one of 'h2h','spreads','totals' plus any alternate normalized away
-    - name_norm is team name for h2h/spreads, or 'Over'/'Under' for totals
-    - point_str is outcome.point (may be signed for spreads, numeric for totals)
-    """
-    key = (mkt_key or "").lower().strip()
+def _user_market_and_label(api_market: str, outcome: dict) -> Tuple[str,str,str]:
+    key = (api_market or "").lower().strip()
     if key.startswith("alternate_"):
         key = key.replace("alternate_", "", 1)
-
-    name = outcome.get("name","") or ""
-    desc = outcome.get("description","") or ""
-    point = outcome.get("point","")
-    # totals: keep Over/Under in name_norm
+    name = outcome.get("name") or outcome.get("description") or ""
+    point = outcome.get("point", "")
     if key == "totals":
-        name_norm = name.split()[0].title()  # Over or Under
-        return "totals", name_norm, str(point or "").replace("Â½","½")
-    # spreads: name is team, keep signed point
-    elif key == "spreads":
-        name_norm = _norm_team(name)
+        side = name.split()[0].title() if name else ""
+        return "totals", side, str(point).replace("Â½","½")
+    if key == "spreads":
+        nm = _norm_team(name)
         p = str(point or "")
-        if p and not p.startswith(("+","-")):
+        if p and p[0] not in "+-":
             p = f"+{p}"
-        return "spreads", name_norm, p.replace("Â½","½")
-    else:
-        # h2h
-        name_norm = _norm_team(name or desc)
-        return "h2h", name_norm, ""
+        return "spreads", nm, p.replace("Â½","½")
+    return "h2h", _norm_team(name), ""
 
-def _rows_for_event(event_id: str, user_market: str, bet_select: str, league: str) -> List[List[str]]:
-    """
-    Fetch per-event odds for allowed books and build rows for Detailed Odds.
-    """
-    rows = []
-    markets = []
-    if user_market.lower().startswith("spreads"):
-        markets = ["spreads","alternate_spreads"]
-    elif user_market.lower().startswith("totals"):
-        markets = ["totals","alternate_totals"]
-    elif user_market.lower() in ("h2h","moneyline","ml"):
-        markets = ["h2h"]
-    elif user_market.lower().startswith("player_"):
-        # out of scope for CLV sync today; skip quietly
-        return rows
+def _fetch_event_odds(event_id: str, user_market: str, user_selection: str, league: str) -> List[List[str]]:
+    m = user_market.lower()
+    if m.startswith("spread"):
+        mkts = "spreads,alternate_spreads"
+    elif m.startswith("total"):
+        mkts = "totals,alternate_totals"
+    elif m in ("h2h","moneyline","ml"):
+        mkts = "h2h"
     else:
-        return rows
-
+        return []
     url = f"https://api.the-odds-api.com/v4/sports/{league}/events/{event_id}/odds"
-    params = {
-        "apiKey": config.ODDS_API_KEY,
-        "regions": config.ODDS_REGIONS,
-        "oddsFormat": config.ODDS_FORMAT,
-        "markets": ",".join(markets)
-    }
-    r = requests.get(url, params=params, timeout=25)
+    params = {"apiKey": config.ODDS_API_KEY, "regions": config.ODDS_REGIONS, "oddsFormat": config.ODDS_FORMAT, "markets": mkts}
+    try:
+        r = requests.get(url, params=params, timeout=25)
+    except Exception as e:
+        print(f"[ERROR] Event odds failed {event_id}: {e}")
+        return []
     if r.status_code != 200:
-        print(f"[WARN] Event {event_id} {league} HTTP {r.status_code}: {r.text[:200]}")
-        return rows
-
-    data = r.json()
-    for bk in data.get("bookmakers", []):
-        if bk.get("key","") not in config.ALLOWED_BOOKS:
+        print(f"[WARN] Event odds {event_id} ({league}) HTTP {r.status_code}: {r.text[:200]}")
+        return []
+    rows: List[List[str]] = []
+    for bk in r.json().get("bookmakers", []):
+        if bk.get("key") not in config.ALLOWED_BOOKS:
             continue
-        bk_title = bk.get("title","")
-        for m in bk.get("markets", []):
-            api_mkt = m.get("key","")
-            for oc in m.get("outcomes", []):
-                user_mkt, name_norm, pt = _build_user_market_and_label(api_mkt, oc, league, bet_select)
-                # Only keep the primary family that matches our bet intent
-                fam = user_market.split("_")[0].lower()
-                if user_mkt != fam:
+        bkname = bk.get("title") or bk.get("key")
+        for market in bk.get("markets", []):
+            api_key = market.get("key","")
+            for oc in market.get("outcomes", []):
+                user_mkt, name_norm, point_str = _user_market_and_label(api_key, oc)
+                base = "h2h" if m in ("h2h","ml","moneyline") else ("spreads" if m.startswith("spread") else "totals")
+                if user_mkt != base:
                     continue
-                rows.append([
-                    event_id,
-                    user_mkt,
-                    bet_select,
-                    bk_title,
-                    api_mkt,
-                    name_norm,
-                    str(pt),
-                    str(oc.get("price",""))
-                ])
+                odds = str(oc.get("price",""))
+                rows.append([event_id, user_mkt, user_selection, bkname, api_key, name_norm, str(point_str), odds])
     return rows
 
 def refresh_detailed_odds_from_bets():
     ws_bets = sheets.open_ws(config.GOOGLE_SHEET_ID, config.BET_SHEET_TAB)
-
-    # read Event ID (col 3), Market (6), Bet (9) from bet rows
-    event_ids = ws_bets.col_values(3)[config.BET_FIRST_DATA_ROW-1:]   # C
-    markets   = ws_bets.col_values(6)[config.BET_FIRST_DATA_ROW-1:]   # F
-    bets      = ws_bets.col_values(9)[config.BET_FIRST_DATA_ROW-1:]   # I
-
-    triplets = []
-    for eid, mkt, sel in zip(event_ids, markets, bets):
-        eid = (eid or "").strip()
-        mkt = (mkt or "").strip().lower()
-        sel = (sel or "").strip()
-        if eid and mkt and sel:
-            triplets.append((eid, mkt, sel))
+    event_ids = ws_bets.col_values(3)[config.BET_FIRST_DATA_ROW - 1:]  # C
+    markets   = ws_bets.col_values(6)[config.BET_FIRST_DATA_ROW - 1:]  # F
+    bets      = ws_bets.col_values(9)[config.BET_FIRST_DATA_ROW - 1:]  # I
+    reqs = [(e.strip(), m.strip(), b.strip()) for e,m,b in zip(event_ids, markets, bets) if e and m and b]
 
     ws_det = sheets.open_ws(config.GOOGLE_SHEET_ID, config.DETAILED_ODDS_TAB)
-    header = [
-        "Event ID","User Market","User Bet Selection","Bookmaker",
-        "API Market","Outcome Name (Normalized)","Outcome Point","Odds"
-    ]
-    sheets.write_header(ws_det, header)
+    header = ["Event ID","User Market","User Bet Selection","Bookmaker","API Market","Outcome Name (Normalized)","Outcome Point","Odds"]
+    sheets.write_header(ws_det, header, header_row=1)
 
-    out_rows = []
-    for i, (eid, mkt, sel) in enumerate(triplets, start=1):
-        # try each league until the event is found
-        found_any = False
+    all_rows: List[List[str]] = []
+    for idx, (eid, mkt, sel) in enumerate(reqs, 1):
         for league in config.LEAGUES:
-            rs = _rows_for_event(eid, mkt, sel, league)
-            if rs:
-                out_rows.extend(rs)
-                found_any = True
+            rows = _fetch_event_odds(eid, mkt, sel, league)
+            if rows:
+                all_rows.extend(rows)
                 break
-        if not found_any:
-            # not fatal, skip if The Odds API doesn't know that event under our chosen leagues
-            pass
-        # small backoff to be gentle with API
-        if i % 10 == 0:
+        if idx % 10 == 0:
             time.sleep(0.5)
-
-    if out_rows:
-        ws_det.update("A2", out_rows, value_input_option="USER_ENTERED")
-    print(f"[Detailed Odds] Wrote {len(out_rows)} rows.")
+    if all_rows:
+        ws_det.update("A2", all_rows, value_input_option="USER_ENTERED")
+    print(f"[Detailed Odds] Wrote {len(all_rows)} rows for {len(reqs)} bets.")
 
 def main():
-    print("Refreshing Live Odds...")
+    print("Odds sync starting...")
     refresh_live_odds()
-    print("Refreshing Detailed Odds (from Bets)...")
     refresh_detailed_odds_from_bets()
-    print("Done.")
+    print("Odds sync completed.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `odds_sync.py` to fetch live events and odds data from The Odds API and write to Google Sheets
- support normalization of team names and mapping of markets to user selections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c473cc0832c87194e08c251feb4