### PR TITLE
Add Google Sheets sync script for Bets tab

### DIFF
--- a/google_sheets_sync.py
+++ b/google_sheets_sync.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from core import sheets
+import config
+
+CSV_PATH = "Bet_Tracking.csv"
+
+def main():
+    ws = sheets.open_ws(config.GOOGLE_SHEET_ID, config.BET_SHEET_TAB)
+    try:
+        df = pd.read_csv(CSV_PATH, dtype=str).fillna("")
+    except FileNotFoundError:
+        print(f"[ERROR] CSV not found: {CSV_PATH}")
+        return
+    # Header alias mapping
+    header_map = {"Bet ID#": "Bet ID"}
+    df.rename(columns={k:v for k,v in header_map.items() if k in df.columns}, inplace=True)
+    # Clear old data rows (keep headers)
+    sheets.clear_below(ws, config.BET_FIRST_DATA_ROW, last_col_letter="Z")
+    if len(df):
+        rows = [list(r) for r in df.to_records(index=False)]
+        ws.update(f"A{config.BET_FIRST_DATA_ROW}", rows, value_input_option="USER_ENTERED")
+    print(f"[Sheets Sync] Synced {len(df)} rows to '{config.BET_SHEET_TAB}'.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `google_sheets_sync.py` to sync `Bet_Tracking.csv` into the Bets tab of the configured Google Sheet
- Normalize header names (e.g. `Bet ID#` to `Bet ID`), clear existing rows, and push CSV rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3df210d8832cbdc7527671a86b7b