### PR TITLE
Graceful gspread dependency check and resilient hybrid runner

### DIFF
--- a/core/logging_utils.py
+++ b/core/logging_utils.py
@@ -1,0 +1,10 @@
+def info(msg: str) -> None:
+    print(f"[INFO] {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"[OK] {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"[WARN] {msg}")

--- a/core/sheets.py
+++ b/core/sheets.py
@@ -1,5 +1,12 @@
 from typing import List
-import gspread
+
+try:
+    import gspread  # type: ignore
+except Exception as e:
+    raise RuntimeError(
+        "Missing dependency 'gspread'. Install it in your runtime environment.\n"
+        "See docs/INSTALL.md for proxy/offline install steps."
+    ) from e
 from google.oauth2.service_account import Credentials
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,24 @@
+# Installing deps behind a proxy / offline
+
+The pipeline needs these PyPI packages in your **runtime** (where scripts run):
+- gspread, google-auth, pandas, requests, python-dotenv
+
+## Option 1 — System proxy env vars (quickest)
+Set before running `pip`:
+```powershell
+$Env:HTTPS_PROXY = "http://user:pass@proxyhost:port"
+$Env:HTTP_PROXY  = "http://user:pass@proxyhost:port"
+python -m pip install --upgrade pip
+python -m pip install gspread google-auth pandas requests python-dotenv
+```
+
+## Option 2 — Offline / air‑gapped install
+On a machine with internet access:
+```bash
+mkdir wheels
+pip download gspread google-auth pandas requests python-dotenv -d wheels
+```
+Copy the `wheels/` folder to the offline machine, then run:
+```bash
+pip install --no-index --find-links=./wheels gspread google-auth pandas requests python-dotenv
+```

--- a/hybrid_script.py
+++ b/hybrid_script.py
@@ -1,22 +1,30 @@
 import subprocess, sys
+from pathlib import Path
+from core.logging_utils import info, ok, warn
 import config
 
 
 def main() -> None:
-    print("=== Pipeline start ===")
+    info("=== Pipeline start ===")
     # 1) Pinnacle
-    try:
-        subprocess.run([sys.executable, "Pinnacle_Scraper.py"], check=True)
-        print("[OK] Pinnacle_Scraper")
-    except subprocess.CalledProcessError as e:
-        print(f"[WARN] Pinnacle_Scraper failed: {e}")
+    if Path("Pinnacle_Scraper.py").exists():
+        try:
+            subprocess.run([sys.executable, "Pinnacle_Scraper.py"], check=True)
+            ok("Pinnacle_Scraper")
+        except subprocess.CalledProcessError as e:
+            warn(f"Pinnacle_Scraper failed: {e}")
+    else:
+        warn("Pinnacle_Scraper.py not found in repo root; skipping Pinnacle scrape.")
     # 2) BetOnline: scraper or CSV merge
     if config.ENABLE_BETONLINE:
-        try:
-            subprocess.run([sys.executable, "BetOnline_Scraper.py"], check=True)
-            print("[OK] BetOnline_Scraper")
-        except subprocess.CalledProcessError as e:
-            print(f"[WARN] BetOnline_Scraper failed: {e}")
+        if Path("BetOnline_Scraper.py").exists():
+            try:
+                subprocess.run([sys.executable, "BetOnline_Scraper.py"], check=True)
+                ok("BetOnline_Scraper")
+            except subprocess.CalledProcessError as e:
+                warn(f"BetOnline_Scraper failed: {e}")
+        else:
+            warn("BetOnline_Scraper.py not found; skipping BetOnline scrape.")
     else:
         subprocess.run([sys.executable, "import_betonline_csv.py"], check=False)
     # 3) Sync bets to Sheets
@@ -25,7 +33,7 @@ def main() -> None:
     subprocess.run([sys.executable, "odds_sync.py"], check=True)
     # 5) CLV → write back
     subprocess.run([sys.executable, "clv_sync.py"], check=True)
-    print("=== Pipeline end ===")
+    info("=== Pipeline end ===")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Raise clear RuntimeError if `gspread` isn't installed, pointing to docs for offline/proxy install
- Hybrid pipeline runner now skips missing scraper scripts instead of aborting
- Document proxy/offline dependency installation steps

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb62f3a7b8832c8280cdf35f214492