### PR TITLE
Expand odds sync league coverage and logging

### DIFF
--- a/Python Project Folder/config.py
+++ b/Python Project Folder/config.py
@@ -26,7 +26,11 @@ DETAILED_ODDS_TAB = os.environ.get("DETAILED_ODDS_TAB", "Detailed Odds")
 
 # --- Odds API (env-driven secret) ---
 ODDS_API_KEY = os.environ.get("ODDS_API_KEY", "")
-LEAGUES = ["baseball_mlb", "americanfootball_nfl"]
+LEAGUES = os.environ.get(
+    "LEAGUES",
+    "baseball_mlb,americanfootball_nfl,americanfootball_ncaaf",
+).split(",")
+LEAGUES = [x.strip() for x in LEAGUES if x.strip()]
 ALLOWED_BOOKS = ["pinnacle", "fanduel", "betonlineag", "draftkings"]
 ODDS_REGIONS = "us"
 ODDS_FORMAT = "american"


### PR DESCRIPTION
## Summary
- Allow configuring leagues from environment with default MLB, NFL and NCAAF
- Iterate over config-provided leagues and log per-league API status and row counts
- Harden event odds fetch by logging full body on non-200 responses

## Testing
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv)*
- `python 'Python Project Folder/odds_sync.py'` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68bba2629068832c91839fe0beb19f1d