### PR TITLE
Canonicalize Google Sheets sync entrypoint

### DIFF
--- a/google_sheets_sync.py
+++ b/google_sheets_sync.py
@@ -1,25 +1,10 @@
-import pandas as pd
-from core import sheets
-import config
+# Thin wrapper to run the canonical sync (with Event-ID backfill)
+import runpy, os, sys
 
-CSV_PATH = "Bet_Tracking.csv"
+BASE = os.path.dirname(os.path.abspath(__file__))
+TARGET = os.path.join(BASE, "Python Project Folder", "google_sheets_sync.py")
 
-def main():
-    ws = sheets.open_ws(config.GOOGLE_SHEET_ID, config.BET_SHEET_TAB)
-    try:
-        df = pd.read_csv(CSV_PATH, dtype=str).fillna("")
-    except FileNotFoundError:
-        print(f"[ERROR] CSV not found: {CSV_PATH}")
-        return
-    # Header alias mapping
-    header_map = {"Bet ID#": "Bet ID"}
-    df.rename(columns={k:v for k,v in header_map.items() if k in df.columns}, inplace=True)
-    # Clear old data rows (keep headers)
-    sheets.clear_below(ws, config.BET_FIRST_DATA_ROW, last_col_letter="Z")
-    if len(df):
-        rows = [list(r) for r in df.to_records(index=False)]
-        ws.update(f"A{config.BET_FIRST_DATA_ROW}", rows, value_input_option="USER_ENTERED")
-    print(f"[Sheets Sync] Synced {len(df)} rows to '{config.BET_SHEET_TAB}'.")
+# Ensure we can import the project's config and modules
+sys.path.insert(0, os.path.join(BASE, "Python Project Folder"))
 
-if __name__ == "__main__":
-    main()
+runpy.run_path(TARGET, run_name="__main__")


### PR DESCRIPTION
## Summary
- Replace root `google_sheets_sync.py` with a thin wrapper that delegates to the canonical script in `Python Project Folder`, ensuring proper `config` imports.

## Testing
- `python 'Python Project Folder/google_sheets_sync.py'` *(fails: No module named 'dotenv')*
- `python google_sheets_sync.py` *(fails: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-dotenv>=1.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bba50bec50832cbd67bd201e541c53