### PR TITLE
Fix datetime import conflict in Pinnacle_Scraper

### DIFF
--- a/Python Project Folder/Pinnacle_Scraper.py
+++ b/Python Project Folder/Pinnacle_Scraper.py
@@ -1,4 +1,5 @@
-import os, sys, time, datetime
+import os, sys, time
+from datetime import datetime
 import csv
 import random, tempfile
 import re
@@ -31,10 +32,10 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 
 def _ts():
-    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
-RUN_ID = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+RUN_ID = datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
 def log(msg):


### PR DESCRIPTION
## Summary
- refactor Pinnacle_Scraper to import `datetime` class instead of module
- update timestamp helpers to call `datetime.now` directly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc4de656ec832c80265ee5409147f1