### PR TITLE
Allow overriding Chrome user data directory via environment

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,6 +41,8 @@ ENABLE_BETONLINE = False
 DEBUG_LOG = True
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")  # INFO|DEBUG
 # Non-default Chrome profile (prevents 'DevTools ... requires non-default data dir' + UC fallback)
-CHROME_USER_DATA_DIR = r"C:\\Users\\jason\\ChromeProfiles\\PinnacleBot"
+CHROME_USER_DATA_DIR = os.getenv(
+    "CHROME_USER_DATA_DIR", r"C:\\Users\\jason\\ChromeProfiles\\PinnacleBot"
+)
 ATTACH_TO_RUNNING = False
 DEBUG_PORT = 9222


### PR DESCRIPTION
## Summary
- Read `CHROME_USER_DATA_DIR` from environment with default to local profile path
- Preserve default Chrome profile dir and running-attach behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc571061a4832c956f5ed5a72b923b