### PR TITLE
Use repo-root credentials path

### DIFF
--- a/Python Project Folder/BetOnline_Scraper.py
+++ b/Python Project Folder/BetOnline_Scraper.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import random
 import csv
@@ -7,7 +8,13 @@ import datetime
 
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 import config
+
+SERVICE_ACCOUNT_FILE = os.path.join(REPO_ROOT, "credentials.json")
 
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -805,7 +812,7 @@ def build_matchup_dict_from_live_odds(spreadsheet_name="Live Odds", sheet_name="
         "https://www.googleapis.com/auth/drive",
     ]
     try:
-        creds = ServiceAccountCredentials.from_json_keyfile_name("credentials.json", scope)
+        creds = ServiceAccountCredentials.from_json_keyfile_name(SERVICE_ACCOUNT_FILE, scope)
         client = gspread.authorize(creds)
         sheet = client.open(spreadsheet_name).worksheet(sheet_name)
         data = sheet.get_all_values()

--- a/core/sheets.py
+++ b/core/sheets.py
@@ -1,4 +1,5 @@
 from typing import List
+import os
 
 try:
     import gspread  # type: ignore
@@ -11,9 +12,13 @@ from google.oauth2.service_account import Credentials
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SERVICE_ACCOUNT_FILE = os.path.join(REPO_ROOT, "credentials.json")
+
 
 def _client():
-    creds = Credentials.from_service_account_file("credentials.json", scopes=SCOPES)
+    print(f"[Sheets] Using credentials at: {SERVICE_ACCOUNT_FILE}")
+    creds = Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
     return gspread.authorize(creds)
 
 


### PR DESCRIPTION
## Summary
- Resolve `credentials.json` relative to repo root for Google Sheets helper and BetOnline scraper
- Log credential path when initializing sheets client
- Replace hard-coded credential path in BetOnline scraper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc576f6b3c832c9590d5fa4914cd09