### PR TITLE
Use config-based sheet resolution for merging event IDs

### DIFF
--- a/Python Project Folder/Pinnacle_Scraper.py
+++ b/Python Project Folder/Pinnacle_Scraper.py
@@ -1171,8 +1171,8 @@ def main():
     grade_settled_bets(driver, csv_path("Bet_Tracking.csv"))
     merge_event_ids_into_csv(
         csv_file=csv_path("Bet_Tracking.csv"),
-        spreadsheet_id="Live Odds",
-        sheet_name="Live Odds"
+        spreadsheet_id=None,  # use config.GOOGLE_SHEET_ID via resolver
+        sheet_name=getattr(config, "LIVE_ODDS_TAB", "Live Odds")
     )
 
     driver.quit()


### PR DESCRIPTION
## Summary
- Resolve Google Sheet ID via `config.GOOGLE_SHEET_ID` when merging event IDs.
- Added sheet resolver helpers and updated BetOnline and backup scrapers accordingly.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc94cf74f0832cb03b45d2f35efb2b